### PR TITLE
Support for python versions ``3.10``+:

### DIFF
--- a/src/python/core.c
+++ b/src/python/core.c
@@ -1,3 +1,5 @@
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include <alloca.h>
 #include <stdint.h>


### PR DESCRIPTION
- Define ``PY_SSIZE_T_CLEAN`` before including ``Python.h``